### PR TITLE
Deployment related changes and reverse proxy configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ hs_err_pid*
 .vagrant
 id_rsa.pub
 secrets
+
+ssl.crt
+ssl.key
+.htpasswd

--- a/Makefile
+++ b/Makefile
@@ -33,22 +33,22 @@ secrets:
 
 build: secrets
 	@echo
-	@echo "Building logindownload.jar"
+	@echo "Building logindownload.jar v$(DOWNLOAD_VERSION)"
 	@echo
 	@rm -f logindownload.jar
-	@docker image build -t fairdownload:1.0-dev . -f Dockerfile
-	@docker container run --publish 8433:8433 --detach --name fairdata-download fairdownload:1.0-dev
+	@docker image build -t fairdownload:$(DOWNLOAD_VERSION)-dev . -f Dockerfile
+	@docker container run --publish 8433:8433 --detach --name fairdata-download fairdownload:$(DOWNLOAD_VERSION)-dev
 	@docker cp fairdata-download:/opt/login-download/logindownload.jar logindownload.jar
 	@docker stop fairdata-download
 	@docker rm fairdata-download
-	@docker rmi fairdownload:1.0-dev
+	@docker rmi fairdownload:$(DOWNLOAD_VERSION)-dev
 	@echo
-	@echo "logindownload.jar is now built."
+	@echo "logindownload.jar v$(DOWNLOAD_VERSION) is now built."
 	@echo
 
 docker-prod: all
 	@echo
-	@echo "Creating production docker image.."
+	@echo "Creating production docker image (fairdownload:$(DOWNLOAD_VERSION)).."
 	@echo
 	-@docker rmi fairdownload:$(DOWNLOAD_VERSION)
 	@docker image build -t fairdownload:$(DOWNLOAD_VERSION) -f Dockerfile.prod .
@@ -59,8 +59,32 @@ docker-prod: all
 docker-prod-run: secrets
 	@docker container run --mount type=bind,source="$(PWD)"/secrets/metax.properties,target=/opt/secrets/metax.properties --mount type=bind,source="$(PWD)"/service/application.properties,target=/opt/login-download/config/application.properties --mount type=bind,source="$(PWD)"/service/config.properties,target=/opt/login-download/config.properties --publish 8433:8433 --detach --name fairdata-download fairdownload:$(DOWNLOAD_VERSION)
 
+secrets/.htpasswd:
+	@htpasswd -db .htpasswd user password
+
+secrets/ssl.crt: certs
+secrets/ssl.key: certs
+
+certs:
+	@test -f secrets/ssl.crt || openssl req -x509 -days 365 -nodes -subj '/C=FI/ST=Uusimaa/L=Espoo/O=CSC - Tieteen tietotekniikan keskus Oy/CN=fairdata-download.csc.local' -addext "subjectAltName = DNS:fairdata-download.csc.local" -addext "extendedKeyUsage = serverAuth" -newkey rsa:2048 -out secrets/ssl.crt -keyout secrets/ssl.key
+
+swarm-deploy: secrets/.htpasswd secrets/ssl.key secrets/ssl.crt
+	@docker stack deploy --compose-file docker-compose.yml fairdownload
+
+swarm-rm:
+	@docker stack rm fairdownload
+
+swarm-init:
+	@docker swarm init
+
+swarm-leave:
+	@docker swarm leave --force
+
+swarm-ps:
+	@docker stack services fairdownload
+
 clean:
-	@rm logindownload.jar
-	@vagrant destroy
+	@rm -f logindownload.jar
 	@rm -rf target
 	@rm -rf .vagrant
+	-@vagrant destroy 2> /dev/null > /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,77 @@
+version: "3.7"
+services:
+    fairdata-download-auth:
+        image: nginx
+        restart: unless-stopped
+        depends_on:
+            - fairdata-download
+        volumes:
+            - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+            - ./nginx/index.html:/usr/share/nginx/html/index.html:ro
+            - ./secrets/.htpasswd:/etc/nginx/.htpasswd:ro
+            - ./secrets/ssl.crt:/etc/nginx/ssl.crt:ro
+            - ./secrets/ssl.key:/etc/nginx/ssl.key:ro
+        networks:
+            - downloadnetwork
+        ports:
+            - "4433:443"
+        deploy:
+            mode: replicated
+            replicas: 1
+            endpoint_mode: vip
+            restart_policy:
+                condition: on-failure
+                delay: 5s
+                max_attempts: 3
+                window: 120s
+            resources:
+                limits:
+                    cpus: '0.50'
+                    memory: 512M
+
+    fairdata-download:
+        image: fairdownload:0.1.3
+        restart: unless-stopped
+        build:
+            context: .
+            dockerfile: Dockerfile.prod
+        networks:
+            - downloadnetwork
+        deploy:
+            mode: replicated
+            replicas: 2
+            endpoint_mode: vip
+            restart_policy:
+                condition: on-failure
+                delay: 5s
+                max_attempts: 3
+                window: 120s
+            resources:
+                limits:
+                    cpus: '1.50'
+                    memory: 2G
+                reservations:
+                    cpus: '0.5'
+                    memory: 512M
+#       logging:
+#           driver: syslog
+#           options:
+#               syslog-address: "tcp://192.168.0.42:123"
+        expose:
+            - "8433"
+        volumes:
+            - type: bind
+              source: ./secrets/metax.properties
+              target: /opt/secrets/metax.properties
+              read_only: true
+            - type: bind
+              source: ./service/application.properties
+              target: /opt/login-download/config/application.properties
+              read_only: true
+            - type: bind
+              source: ./service/config.properties
+              target: /opt/login-download/config.properties
+              read_only: true
+
+networks:
+    downloadnetwork:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,23 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    listen 443 ssl;
+    ssl_certificate     /etc/nginx/ssl.crt;
+    ssl_certificate_key /etc/nginx/ssl.key;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    location /secure {
+        auth_basic           "Basic auth";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        proxy_pass   http://fairdata-download:8433/secure/;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/nginx/index.html
+++ b/nginx/index.html
@@ -1,0 +1,1 @@
+download service


### PR DESCRIPTION
This PR contains a simple configuration for docker swarm deployment, also adds a docker-compose file which contains the overall configuration of the download service.

The etsin is communicating to port 4433 and is expecting to see http basic auth and ssl. This PR contains the required changes to be compatible with the current implementation.

This has also the secrets/ directory which is not shipped with this PR, but the content can be created for testing purposes with make.