### PR TITLE
CSCFAIRADM-221: Change contentLength to long

### DIFF
--- a/src/main/java/fi/csc/fairdata/logindl/Tiedostonkäsittely.java
+++ b/src/main/java/fi/csc/fairdata/logindl/Tiedostonkäsittely.java
@@ -78,7 +78,7 @@ public class Tiedostonkäsittely  {
 
 			con.setRequestProperty("Authorization", "Basic " + encoding);
 			con.setRequestMethod("GET");
-			hsr.setContentLengthLong(con.getContentLength()); //idabytes?
+			hsr.setContentLengthLong(con.getContentLengthLong()); //idabytes?
 			hsr.setContentType("application/octet-stream");  		
 			String[] sa = t.getFile_path().split("/");
 			String filename = sa[sa.length-1];


### PR DESCRIPTION
This enables viewing file size in the web browser, while downloading, for files larger than 2GB.