### PR TITLE
CSCFAIRADM-221: .jar version update and reset RAM limit to 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <groupId>fi.csc.fairdata</groupId>
   <artifactId>logindownload</artifactId>
-  <version>0.1.4</version>
+  <version>0.1.5</version>
   <name>fairdata login download</name>
   <description>downloads from UIDA. Called from etsin. Require login</description>
   <properties>

--- a/service/start-fairdata-download.sh
+++ b/service/start-fairdata-download.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 pushd /opt/login-download
-java -Xmx12g -XX:MaxMetaspaceSize=180M -XX:MaxGCPauseMillis=5000 -jar logindownload.jar
+java -Xmx6g -XX:MaxMetaspaceSize=180M -verbose -jar logindownload-0.1.5.jar --trace
 popd


### PR DESCRIPTION
- .jar version should be updated (0.1.5), as there was a new change (getContentLengthLong())
- Re-add RAM limit = 6, as before. 12 not needed.